### PR TITLE
Fix incorrect path for sdk-js module

### DIFF
--- a/javascript-sdk/package.json
+++ b/javascript-sdk/package.json
@@ -3,7 +3,7 @@
   "version": "2.5.5",
   "description": "Jitsu JavaScript SDK (more at http://jitsu.com/docs/js-sdk)",
   "main": "dist/npm/jitsu.cjs.js",
-  "module": "dist/npm/dist/jitsu.es.js",
+  "module": "dist/npm/jitsu.es.js",
   "types": "dist/npm/jitsu.d.ts",
   "files": [
     "dist/npm/*",


### PR DESCRIPTION
This fixes the broken NPM module when trying to `import "@jitsu/sdk-js"`